### PR TITLE
Fix: userParam method was renamed to userParams

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -61,7 +61,7 @@ export function createMetrika (Vue) {
             reachGoal() {if (config.debug) {console.log('[vue-yandex-metrika] reachGoal:', arguments)}},
             replacePhones() {if (config.debug) {console.log('[vue-yandex-metrika] replacePhones:', arguments)}},
             setUserID() {if (config.debug) {console.log('[vue-yandex-metrika] setUserID:', arguments)}},
-            userParam() {if (config.debug) {console.log('[vue-yandex-metrika] userParam:', arguments)}}
+            userParams() {if (config.debug) {console.log('[vue-yandex-metrika] userParams:', arguments)}}
         }
     }
 }


### PR DESCRIPTION
**What**: Method `userParams` is not defined with development env.

**Why**: Docs: https://yandex.ru/support/metrica/objects/user-params.html?lang=en

**How**: Fixed: userParam method was renamed to userParams
